### PR TITLE
Ensure columns length always the same

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Export Job
-The exprot job repository contains several job that generate an export product.
+The export job repository contains several job that generate an export product.
 This repository is closely associated with the exporter-backend which schedules the jobs.
 Within this repository you can find multiple jobs, the profiles will show which jobs are available.
 The jobs share the AbstractExportJobService class and are triggered through the ProjectRunner.
@@ -28,7 +28,7 @@ This is why we use some magic to always include fields that are mapped to a ods:
 ## DwC-DP
 This job contains some additional complexity as we need to potentially deduplicate records.
 This means that when the job is started we will create some temporary database tables.
-Just as the other jobs we will paginate over elatic and retrieve all data, after which we will also collect any media associated with the specimen.
+Just as the other jobs we will paginate over elastic and retrieve all data, after which we will also collect any media associated with the specimen.
 We then parse this to DwC-DP records and we generate any identifiers when they are not present.
 These identifiers are essential in creating the linkages between the different files in the DwC-DP.
 The generate identifiers are based on the data in the object (essential for deduplication) and we use an MD5 hash.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Export Job
+The exprot job repository contains several job that generate an export product.
+This repository is closely associated with the exporter-backend which schedules the jobs.
+Within this repository you can find multiple jobs, the profiles will show which jobs are available.
+The jobs share the AbstractExportJobService class and are triggered through the ProjectRunner.
+The exports of the jobs are stored in an S3 bucket and can be downloaded from there (see the S3Repository).
+
+## Source System Jobs
+There are some jobs which are specifically for a source system.
+The results of these jobs will be available through the source-system endpoint and can be used for example by GBIF.
+The difference with other jobs is that we include the original `eml.xml` for the source system.
+
+# Jobs
+## DoiList
+This job generates a zipped csv file containing just two columns, the DOI of the specimen and the physicalSpecimenID.
+It is straightforward, paginates over elastic and retrieves only these two fields and writes the result to a file.
+
+## DWCA
+This job generates a Darwin Core Archive (DwC-A) file containing all the specimen data.
+It paginates over elastic and retrieves all data, it then retrieve all media associated with the specimen.
+For building the DwC-A we use the GBIF dwca-io [library](https://github.com/gbif/dwca-io).
+However, we did implement our own DWCA writer (DwcaZipWriter) as the GBIF implementation did not support streaming to a zipped file.
+The DwcaZipWriter is based on this [GBIF stream writer](https://github.com/gbif/dwca-io/blob/master/src/main/java/org/gbif/dwc/DwcaStreamWriter.java)
+Then we build the DwC-A where it is important that we include all fields in the correct order.
+Based on the first records we determine the order of the fields and this will determine the `meta.xml` file.
+This is why we use some magic to always include fields that are mapped to a ods:Location even if the location might not be present in the record.
+
+## DwC-DP
+This job contains some additional complexity as we need to potentially deduplicate records.
+This means that when the job is started we will create some temporary database tables.
+Just as the other jobs we will paginate over elatic and retrieve all data, after which we will also collect any media associated with the specimen.
+We then parse this to DwC-DP records and we generate any identifiers when they are not present.
+These identifiers are essential in creating the linkages between the different files in the DwC-DP.
+The generate identifiers are based on the data in the object (essential for deduplication) and we use an MD5 hash.
+We then store the records in the temporary database tables with the identifier as key and the records as a binary array (blob).
+This steps takes care of the deduplication as we will ignore any records that have the same primary key (on conflict do nothing).
+This concludes the processSearchResults step.
+We then move to the postProcessResults which retrieve each record from the temporary database tables and writes them to the DwC-DP files.
+We then upload this DwC-DP to the S3 bucket.

--- a/src/main/java/eu/dissco/exportjob/component/DwcaZipWriter.java
+++ b/src/main/java/eu/dissco/exportjob/component/DwcaZipWriter.java
@@ -93,11 +93,11 @@ public class DwcaZipWriter {
 
   private void writeRow(Term rowType, String[] row) throws IOException {
     var writerInfo = writers.get(rowType);
-    var maxMappingColumn = writerInfo.getRight();
+    var expectedRowLength = writerInfo.getRight();
     var writer = writerInfo.getLeft();
-    if (row.length > maxMappingColumn) {
+    if (row.length != expectedRowLength) {
       throw new IllegalArgumentException(
-          "Input rows are not equal to the defined mapping of " + maxMappingColumn + " columns.");
+          "Input rows are not equal to the defined mapping of " + expectedRowLength + " columns.");
     }
     writer.write(row);
   }
@@ -108,12 +108,12 @@ public class DwcaZipWriter {
       throw new IllegalArgumentException(
           "The writer mapping for term: " + CORE_ID_TERM.simpleName() + " must not be empty.");
     }
-    final int maxMapping = maxMappingColumn(mapping);
+    final int maxMapping = expectedRowLength(mapping);
     TabWriter writer = addArchiveFile(rowType, mapping);
     writers.put(rowType, Pair.of(writer, maxMapping));
   }
 
-  private int maxMappingColumn(Map<Term, Integer> mapping) {
+  private int expectedRowLength(Map<Term, Integer> mapping) {
     var addOneForLengthChecking = 1;
     return mapping.values().stream().max(Integer::compareTo).orElseThrow()
         + addOneForLengthChecking;

--- a/src/main/java/eu/dissco/exportjob/domain/TargetType.java
+++ b/src/main/java/eu/dissco/exportjob/domain/TargetType.java
@@ -1,7 +1,5 @@
 package eu.dissco.exportjob.domain;
 
-import java.util.HashMap;
-import java.util.Map;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 

--- a/src/main/java/eu/dissco/exportjob/service/AbstractExportJobService.java
+++ b/src/main/java/eu/dissco/exportjob/service/AbstractExportJobService.java
@@ -62,7 +62,8 @@ public abstract class AbstractExportJobService {
     }
   }
 
-  protected boolean processRequest(JobRequest jobRequest) throws IOException {
+  protected boolean processRequest(JobRequest jobRequest)
+      throws IOException, FailedProcessingException {
     String lastId = null;
     writeHeaderToFile();
     boolean keepSearching = true;
@@ -107,7 +108,8 @@ public abstract class AbstractExportJobService {
   protected abstract void postProcessResults(JobRequest jobRequest)
       throws IOException, FailedProcessingException;
 
-  protected abstract void processSearchResults(List<JsonNode> searchResults) throws IOException;
+  protected abstract void processSearchResults(List<JsonNode> searchResults)
+      throws IOException, FailedProcessingException;
 
   protected abstract List<String> targetFields();
 

--- a/src/main/java/eu/dissco/exportjob/service/DwcaService.java
+++ b/src/main/java/eu/dissco/exportjob/service/DwcaService.java
@@ -57,25 +57,19 @@ public class DwcaService extends AbstractExportJobService {
 
   public static final Predicate<DigitalSpecimen> EVENT_CHECK = ds -> ds.getOdsHasEvents() == null
       || ds.getOdsHasEvents().isEmpty();
+  public static final Predicate<DigitalSpecimen> LOCATION_CHECK = EVENT_CHECK.or(
+      ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation() == null);
+  public static final Predicate<DigitalSpecimen> GEOLOGICAL_CONTEXT_CHECK = LOCATION_CHECK.or(
+      ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeologicalContext()
+          == null);
+  public static final Predicate<DigitalSpecimen> GEOREFERENCE_CHECK = LOCATION_CHECK.or(ds ->
+      ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeoreference() == null);
   public static final Function<DigitalSpecimen, Object> EVENT_GET = ds -> ds.getOdsHasEvents()
       .getFirst();
-  public static final Predicate<DigitalSpecimen> LOCATION_CHECK = ds ->
-      ds.getOdsHasEvents() == null || ds.getOdsHasEvents().isEmpty()
-          || ds.getOdsHasEvents().getFirst().getOdsHasLocation() == null;
   public static final Function<DigitalSpecimen, Object> LOCATION_GET = ds -> ds.getOdsHasEvents()
       .getFirst().getOdsHasLocation();
-  public static final Predicate<DigitalSpecimen> GEOLOGICAL_CONTEXT_CHECK = ds ->
-      ds.getOdsHasEvents() == null || ds.getOdsHasEvents().isEmpty()
-          || ds.getOdsHasEvents().getFirst().getOdsHasLocation() == null
-          || ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeologicalContext()
-          == null;
   public static final Function<DigitalSpecimen, Object> GEOLOGICAL_CONTEXT_GET = ds -> ds.getOdsHasEvents()
       .getFirst().getOdsHasLocation().getOdsHasGeologicalContext();
-  public static final Predicate<DigitalSpecimen> GEOREFERENCE_CHECK = ds ->
-      ds.getOdsHasEvents() == null || ds.getOdsHasEvents().isEmpty()
-          || ds.getOdsHasEvents().getFirst().getOdsHasLocation() == null
-          || ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeoreference()
-          == null;
   public static final Function<DigitalSpecimen, Object> GEOREFERENCE_GET = ds -> ds.getOdsHasEvents()
       .getFirst().getOdsHasLocation().getOdsHasGeoreference();
 

--- a/src/main/java/eu/dissco/exportjob/service/DwcaService.java
+++ b/src/main/java/eu/dissco/exportjob/service/DwcaService.java
@@ -55,23 +55,22 @@ import org.springframework.stereotype.Service;
 @Profile(Profiles.DWCA)
 public class DwcaService extends AbstractExportJobService {
 
-  public static final Predicate<DigitalSpecimen> EVENT_CHECK = ds -> ds.getOdsHasEvents() == null
-      || ds.getOdsHasEvents().isEmpty();
-  public static final Predicate<DigitalSpecimen> LOCATION_CHECK = EVENT_CHECK.or(
-      ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation() == null);
-  public static final Predicate<DigitalSpecimen> GEOLOGICAL_CONTEXT_CHECK = LOCATION_CHECK.or(
-      ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeologicalContext()
-          == null);
-  public static final Predicate<DigitalSpecimen> GEOREFERENCE_CHECK = LOCATION_CHECK.or(ds ->
-      ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeoreference() == null);
-  public static final Function<DigitalSpecimen, Object> EVENT_GET = ds -> ds.getOdsHasEvents()
-      .getFirst();
-  public static final Function<DigitalSpecimen, Object> LOCATION_GET = ds -> ds.getOdsHasEvents()
-      .getFirst().getOdsHasLocation();
-  public static final Function<DigitalSpecimen, Object> GEOLOGICAL_CONTEXT_GET = ds -> ds.getOdsHasEvents()
-      .getFirst().getOdsHasLocation().getOdsHasGeologicalContext();
-  public static final Function<DigitalSpecimen, Object> GEOREFERENCE_GET = ds -> ds.getOdsHasEvents()
-      .getFirst().getOdsHasLocation().getOdsHasGeoreference();
+  public static final Pair<Predicate<DigitalSpecimen>, Function<DigitalSpecimen, Object>> EVENT_FUNCTIONS =
+      Pair.of(ds -> ds.getOdsHasEvents() == null || ds.getOdsHasEvents().isEmpty(),
+          ds -> ds.getOdsHasEvents().getFirst());
+  public static final Pair<Predicate<DigitalSpecimen>, Function<DigitalSpecimen, Object>> LOCATION_FUNCTIONS =
+      Pair.of(EVENT_FUNCTIONS.getLeft().or(
+              ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation() == null),
+          ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation());
+  public static final Pair<Predicate<DigitalSpecimen>, Function<DigitalSpecimen, Object>> GEOLOGICAL_CONTEXT_FUNCTIONS =
+      Pair.of(LOCATION_FUNCTIONS.getLeft()
+              .or(ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeologicalContext()
+                  == null),
+          ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeologicalContext());
+  public static final Pair<Predicate<DigitalSpecimen>, Function<DigitalSpecimen, Object>> GEOREFERENCE_FUNCTIONS =
+      Pair.of(LOCATION_FUNCTIONS.getLeft().or(ds ->
+              ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeoreference() == null),
+          ds -> ds.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeoreference());
 
 
   private final ObjectMapper objectMapper;
@@ -163,203 +162,203 @@ public class DwcaService extends AbstractExportJobService {
       ArrayList<Pair<Term, String>> occurrenceRecord)
       throws FailedProcessingException {
     occurrenceRecord.add(Pair.of(DwcTerm.sex,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcSex")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcSex")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.lifeStage,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcLifeStage")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcLifeStage")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.reproductiveCondition,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET,
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS,
                 "getDwcReproductiveCondition")));
     occurrenceRecord.add(Pair.of(DwcTerm.caste,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcCaste")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcCaste")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.behavior,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcBehavior")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcBehavior")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.vitality,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcVitality")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcVitality")));
     occurrenceRecord.add(Pair.of(DwcTerm.establishmentMeans,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcEstablishmentMeans")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcEstablishmentMeans")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.degreeOfEstablishment,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET,
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS,
                 "getDwcDegreeOfEstablishment")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.pathway,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcPathway")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcPathway")));
     occurrenceRecord.add(Pair.of(DwcTerm.georeferenceVerificationStatus,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET,
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS,
             "getDwcGeoreferenceVerificationStatus")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.eventType,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcEventType")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcEventType")));
     occurrenceRecord.add(
-        Pair.of(DwcTerm.fieldNotes,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcFieldNumber")));
+        Pair.of(DwcTerm.fieldNumber,
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcFieldNumber")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.eventDate,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcEventDate")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcEventDate")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.eventTime,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcEventTime")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcEventTime")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.startDayOfYear,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcStartDayOfYear")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcStartDayOfYear")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.endDayOfYear,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcEndDayOfYear")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcEndDayOfYear")));
     occurrenceRecord.add(Pair.of(DwcTerm.year,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcYear")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcYear")));
     occurrenceRecord.add(Pair.of(DwcTerm.month,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcMonth")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcMonth")));
     occurrenceRecord.add(Pair.of(DwcTerm.day,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcDay")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcDay")));
     occurrenceRecord.add(Pair.of(DwcTerm.verbatimEventDate,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcVerbatimEventDate")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcVerbatimEventDate")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.habitat,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcHabitat")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcHabitat")));
     occurrenceRecord.add(Pair.of(DwcTerm.samplingProtocol,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcSamplingProtocol")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcSamplingProtocol")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.sampleSizeValue,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcSampleSizeValue")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcSampleSizeValue")));
     occurrenceRecord.add(Pair.of(DwcTerm.sampleSizeUnit,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcSampleSizeUnit")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcSampleSizeUnit")));
     occurrenceRecord.add(Pair.of(DwcTerm.samplingEffort,
-        retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcSamplingEffort")));
+        retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcSamplingEffort")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.fieldNotes,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcFieldNotes")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcFieldNotes")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.eventRemarks,
-            retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcEventRemarks")));
+            retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, "getDwcEventRemarks")));
     occurrenceRecord.add(Pair.of(DwcTerm.eventID, digitalSpecimen.getId()));
   }
 
   private void mapLocation(DigitalSpecimen digitalSpecimen,
       ArrayList<Pair<Term, String>> occurrenceRecord) throws FailedProcessingException {
     occurrenceRecord.add(Pair.of(DwcTerm.locationID,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getId")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getId")));
     occurrenceRecord.add(Pair.of(DwcTerm.higherGeography,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcHigherGeography")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcHigherGeography")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.higherGeographyID,
-            retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+            retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
                 "getDwcHigherGeographyID")));
     occurrenceRecord.add(Pair.of(DwcTerm.continent,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcContinent")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcContinent")));
     occurrenceRecord.add(Pair.of(DwcTerm.waterBody,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcWaterBody")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcWaterBody")));
     occurrenceRecord.add(Pair.of(DwcTerm.island,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcIsland")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcIsland")));
     occurrenceRecord.add(Pair.of(DwcTerm.islandGroup,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcIslandGroup")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcIslandGroup")));
     occurrenceRecord.add(Pair.of(DwcTerm.country,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcCountry")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcCountry")));
     occurrenceRecord.add(Pair.of(DwcTerm.countryCode,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcCountryCode")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcCountryCode")));
     occurrenceRecord.add(Pair.of(DwcTerm.stateProvince,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcStateProvince")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcStateProvince")));
     occurrenceRecord.add(Pair.of(DwcTerm.county,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcCounty")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcCounty")));
     occurrenceRecord.add(Pair.of(DwcTerm.municipality,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcMunicipality")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcMunicipality")));
     occurrenceRecord.add(Pair.of(DwcTerm.locality,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcLocality")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcLocality")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.verbatimLocality,
-            retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+            retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
                 "getDwcVerbatimLocality")));
     occurrenceRecord.add(Pair.of(DwcTerm.minimumElevationInMeters,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
             "getDwcMinimumElevationInMeters")));
     occurrenceRecord.add(Pair.of(DwcTerm.maximumElevationInMeters,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
             "getDwcMaximumElevationInMeters")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.verbatimElevation,
-            retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+            retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
                 "getDwcVerbatimElevation")));
     occurrenceRecord.add(Pair.of(DwcTerm.minimumDepthInMeters,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
             "getDwcMinimumDepthInMeters")));
     occurrenceRecord.add(Pair.of(DwcTerm.maximumDepthInMeters,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
             "getDwcMaximumDepthInMeters")));
     occurrenceRecord.add(Pair.of(DwcTerm.verbatimDepth,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcVerbatimDepth")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcVerbatimDepth")));
     occurrenceRecord.add(Pair.of(DwcTerm.maximumDistanceAboveSurfaceInMeters,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
             "getDwcMaximumDistanceAboveSurfaceInMeters")));
     occurrenceRecord.add(Pair.of(DwcTerm.minimumDistanceAboveSurfaceInMeters,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
             "getDwcMinimumDistanceAboveSurfaceInMeters")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.locationAccordingTo,
-            retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET,
+            retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS,
                 "getDwcLocationAccordingTo")));
     occurrenceRecord.add(Pair.of(DwcTerm.locationRemarks,
-        retrieveTerm(digitalSpecimen, LOCATION_CHECK, LOCATION_GET, "getDwcLocationRemarks")));
+        retrieveTerm(digitalSpecimen, LOCATION_FUNCTIONS, "getDwcLocationRemarks")));
   }
 
   private void mapGeologicalContext(
       DigitalSpecimen digitalSpecimen, ArrayList<Pair<Term, String>> occurrenceRecord)
       throws FailedProcessingException {
     occurrenceRecord.add(Pair.of(DwcTerm.geologicalContextID,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getId")));
     occurrenceRecord.add(Pair.of(DwcTerm.earliestEonOrLowestEonothem,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcEarliestEonOrLowestEonothem")));
     occurrenceRecord.add(Pair.of(DwcTerm.latestEonOrHighestEonothem,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLatestEonOrHighestEonothem")));
     occurrenceRecord.add(Pair.of(DwcTerm.earliestEraOrLowestErathem,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcEarliestEraOrLowestErathem")));
     occurrenceRecord.add(Pair.of(DwcTerm.latestEraOrHighestErathem,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLatestEraOrHighestErathem")));
     occurrenceRecord.add(Pair.of(DwcTerm.earliestPeriodOrLowestSystem,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcEarliestPeriodOrLowestSystem")));
     occurrenceRecord.add(Pair.of(DwcTerm.latestPeriodOrHighestSystem,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLatestPeriodOrHighestSystem")));
     occurrenceRecord.add(Pair.of(DwcTerm.earliestEpochOrLowestSeries,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcEarliestEpochOrLowestSeries")));
     occurrenceRecord.add(Pair.of(DwcTerm.latestEpochOrHighestSeries,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLatestEpochOrHighestSeries")));
     occurrenceRecord.add(Pair.of(DwcTerm.earliestAgeOrLowestStage,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcEarliestAgeOrLowestStage")));
     occurrenceRecord.add(Pair.of(DwcTerm.latestAgeOrHighestStage,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLatestAgeOrHighestStage")));
     occurrenceRecord.add(Pair.of(DwcTerm.lowestBiostratigraphicZone,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLowestBiostratigraphicZone")));
     occurrenceRecord.add(Pair.of(DwcTerm.highestBiostratigraphicZone,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcHighestBiostratigraphicZone")));
     occurrenceRecord.add(Pair.of(DwcTerm.lithostratigraphicTerms,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcLithostratigraphicTerms")));
     occurrenceRecord.add(Pair.of(DwcTerm.group,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcGroup")));
     occurrenceRecord.add(Pair.of(DwcTerm.formation,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcFormation")));
     occurrenceRecord.add(Pair.of(DwcTerm.member,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcMember")));
     occurrenceRecord.add(Pair.of(DwcTerm.bed,
-        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_CHECK, GEOLOGICAL_CONTEXT_GET,
+        retrieveTerm(digitalSpecimen, GEOLOGICAL_CONTEXT_FUNCTIONS,
             "getDwcBed")));
   }
 
@@ -512,64 +511,64 @@ public class DwcaService extends AbstractExportJobService {
       ArrayList<Pair<Term, String>> occurrenceRecord) throws FailedProcessingException {
     occurrenceRecord.add(
         Pair.of(DwcTerm.decimalLatitude,
-            retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+            retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
                 "getDwcDecimalLatitude")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.decimalLongitude,
-            retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+            retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
                 "getDwcDecimalLongitude")));
     occurrenceRecord.add(Pair.of(DwcTerm.geodeticDatum,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcGeodeticDatum")));
     occurrenceRecord.add(Pair.of(DwcTerm.coordinateUncertaintyInMeters,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcCoordinateUncertaintyInMeters")));
     occurrenceRecord.add(Pair.of(DwcTerm.coordinatePrecision,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcCoordinatePrecision")));
     occurrenceRecord.add(Pair.of(DwcTerm.pointRadiusSpatialFit,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcPointRadiusSpatialFit")));
     occurrenceRecord.add(Pair.of(DwcTerm.verbatimCoordinates,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcVerbatimCoordinates")));
     occurrenceRecord.add(Pair.of(DwcTerm.verbatimLatitude,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcVerbatimLatitude")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.verbatimLongitude,
-            retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+            retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
                 "getDwcVerbatimLongitude")));
     occurrenceRecord.add(Pair.of(DwcTerm.verbatimCoordinateSystem,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcVerbatimCoordinateSystem")));
     occurrenceRecord.add(Pair.of(DwcTerm.verbatimSRS,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET, "getDwcVerbatimSRS")));
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS, "getDwcVerbatimSRS")));
     occurrenceRecord.add(Pair.of(DwcTerm.footprintWKT,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET, "getDwcFootprintWKT")));
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS, "getDwcFootprintWKT")));
     occurrenceRecord.add(Pair.of(DwcTerm.footprintSRS,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET, "getDwcFootprintSRS")));
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS, "getDwcFootprintSRS")));
     occurrenceRecord.add(Pair.of(DwcTerm.footprintSpatialFit,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcFootprintSpatialFit")));
     occurrenceRecord.add(Pair.of(DwcTerm.georeferencedBy,
         retrieveCombinedAgentName(retrieveGeoreferenceAgent(digitalSpecimen), null)));
     occurrenceRecord.add(Pair.of(DwcTerm.georeferencedDate,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcGeoreferencedDate")));
     occurrenceRecord.add(Pair.of(DwcTerm.georeferenceProtocol,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcGeoreferenceProtocol")));
     occurrenceRecord.add(Pair.of(DwcTerm.georeferenceSources,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcGeoreferenceSources")));
     occurrenceRecord.add(Pair.of(DwcTerm.georeferenceRemarks,
-        retrieveTerm(digitalSpecimen, GEOREFERENCE_CHECK, GEOREFERENCE_GET,
+        retrieveTerm(digitalSpecimen, GEOREFERENCE_FUNCTIONS,
             "getDwcGeoreferenceRemarks")));
   }
 
   private List<Agent> retrieveGeoreferenceAgent(DigitalSpecimen digitalSpecimen) {
-    if (GEOREFERENCE_CHECK.test(digitalSpecimen)) {
+    if (GEOREFERENCE_FUNCTIONS.getLeft().test(digitalSpecimen)) {
       return null;
     }
     return digitalSpecimen.getOdsHasEvents().getFirst().getOdsHasLocation().getOdsHasGeoreference()

--- a/src/main/java/eu/dissco/exportjob/service/DwcaService.java
+++ b/src/main/java/eu/dissco/exportjob/service/DwcaService.java
@@ -165,7 +165,7 @@ public class DwcaService extends AbstractExportJobService {
     occurrenceRecord.add(Pair.of(DwcTerm.sex,
         retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcSex")));
     occurrenceRecord.add(
-        Pair.of(DwcTerm.sex,
+        Pair.of(DwcTerm.lifeStage,
             retrieveTerm(digitalSpecimen, EVENT_CHECK, EVENT_GET, "getDwcLifeStage")));
     occurrenceRecord.add(
         Pair.of(DwcTerm.reproductiveCondition,

--- a/src/main/java/eu/dissco/exportjob/utils/ExportUtils.java
+++ b/src/main/java/eu/dissco/exportjob/utils/ExportUtils.java
@@ -12,6 +12,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import org.apache.commons.lang3.tuple.Pair;
 
 public class ExportUtils {
 
@@ -84,14 +85,15 @@ public class ExportUtils {
     return String.join(" | ", agentNames);
   }
 
-  public static String retrieveTerm(DigitalSpecimen digitalSpecimen, Predicate<DigitalSpecimen> condition,
-      Function<DigitalSpecimen, Object> extractor, String methodName)
+  public static String retrieveTerm(DigitalSpecimen digitalSpecimen,
+      Pair<Predicate<DigitalSpecimen>, Function<DigitalSpecimen, Object>> functions,
+      String methodName)
       throws FailedProcessingException {
-    if (condition.test(digitalSpecimen)) {
+    if (functions.getLeft().test(digitalSpecimen)) {
       return null;
     }
-    var event = extractor.apply(digitalSpecimen);
-    return retrieveValueFromClass(event, methodName);
+    var classInstance = functions.getRight().apply(digitalSpecimen);
+    return retrieveValueFromClass(classInstance, methodName);
   }
 
   private static String retrieveValueFromClass(Object classInstance, String methodName)

--- a/src/main/java/eu/dissco/exportjob/utils/ExportUtils.java
+++ b/src/main/java/eu/dissco/exportjob/utils/ExportUtils.java
@@ -1,13 +1,17 @@
 package eu.dissco.exportjob.utils;
 
+import eu.dissco.exportjob.exceptions.FailedProcessingException;
 import eu.dissco.exportjob.schema.Agent;
 import eu.dissco.exportjob.schema.DigitalSpecimen;
 import eu.dissco.exportjob.schema.Identifier;
 import eu.dissco.exportjob.schema.OdsHasRole;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
 import java.util.Set;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 public class ExportUtils {
 
@@ -78,6 +82,30 @@ public class ExportUtils {
       }
     }
     return String.join(" | ", agentNames);
+  }
+
+  public static String retrieveTerm(DigitalSpecimen digitalSpecimen, Predicate<DigitalSpecimen> condition,
+      Function<DigitalSpecimen, Object> extractor, String methodName)
+      throws FailedProcessingException {
+    if (condition.test(digitalSpecimen)) {
+      return null;
+    }
+    var event = extractor.apply(digitalSpecimen);
+    return retrieveValueFromClass(event, methodName);
+  }
+
+  private static String retrieveValueFromClass(Object classInstance, String methodName)
+      throws FailedProcessingException {
+    try {
+      var method = classInstance.getClass().getMethod(methodName);
+      var result = method.invoke(classInstance);
+      if (result != null) {
+        return String.valueOf(result);
+      }
+    } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+      throw new FailedProcessingException("Failed to retrieve value from class", e);
+    }
+    return null;
   }
 
 }

--- a/src/test/java/eu/dissco/exportjob/utils/ExportUtilsTest.java
+++ b/src/test/java/eu/dissco/exportjob/utils/ExportUtilsTest.java
@@ -11,7 +11,6 @@ import eu.dissco.exportjob.schema.DigitalSpecimen;
 import eu.dissco.exportjob.schema.Event;
 import eu.dissco.exportjob.schema.Identifier;
 import eu.dissco.exportjob.schema.OdsHasRole;
-import eu.dissco.exportjob.service.DwcaService;
 import java.util.List;
 import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/eu/dissco/exportjob/utils/ExportUtilsTest.java
+++ b/src/test/java/eu/dissco/exportjob/utils/ExportUtilsTest.java
@@ -1,6 +1,7 @@
 package eu.dissco.exportjob.utils;
 
 
+import static eu.dissco.exportjob.service.DwcaService.EVENT_FUNCTIONS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -164,8 +165,7 @@ class ExportUtilsTest {
     // Given
 
     // When
-    var result = ExportUtils.retrieveTerm(digitalSpecimen, DwcaService.EVENT_CHECK,
-        DwcaService.EVENT_GET, methodName);
+    var result = ExportUtils.retrieveTerm(digitalSpecimen, EVENT_FUNCTIONS, methodName);
 
     // Then
     assertThat(result).isEqualTo(expected);
@@ -178,8 +178,7 @@ class ExportUtilsTest {
     // When / Then
     assertThrows(FailedProcessingException.class,
         () -> ExportUtils.retrieveTerm(new DigitalSpecimen().withOdsHasEvents(List.of(new Event())),
-            DwcaService.EVENT_CHECK,
-            DwcaService.EVENT_GET, "unknownMethod"));
+            EVENT_FUNCTIONS, "unknownMethod"));
 
   }
 

--- a/src/test/java/eu/dissco/exportjob/utils/ExportUtilsTest.java
+++ b/src/test/java/eu/dissco/exportjob/utils/ExportUtilsTest.java
@@ -2,7 +2,7 @@ package eu.dissco.exportjob.utils;
 
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import eu.dissco.exportjob.exceptions.FailedProcessingException;
 import eu.dissco.exportjob.schema.Agent;


### PR DESCRIPTION
Ok last fix didn't fix everything.
If the first record does not contain a location it would not add location, georeference, etc...
However, if the second row does contain this info we have an issue as we base the column length and the meta.xml on the first row.
This PR ensure that we always add these columns even when it is null.
I use a bit of functional programming and reflection as it would get really unhandlable otherwise.
Scary, yes :fearful:  but the reflection is only for public methods, it just calls the getMethod but then without the normal strictness of Java.
This makes it generic and we can just for each method check the stuff and add if there is something there.
I would rather not do the predicate each time but if we keep it generic I don't think there is another way.

Oh and remembered your comment last time so added a readme.md
