### PR TITLE
Add additional mapping to DWCA and DwC-DP

### DIFF
--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpChronometricAge.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpChronometricAge.java
@@ -1,0 +1,34 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpChronometricAge implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private String chronometricAgeID;
+  private String eventID;
+  private String verbatimChronometricAge;
+  private String chronometricAgeProtocol;
+  private String chronometricAgeProtocolID;
+  private String uncalibratedChronometricAge;
+  private String chronometricAgeConversionProtocol;
+  private String chronometricAgeConversionProtocolID;
+  private String earliestChronometricAge;
+  private String earliestChronometricAgeReferenceSystem;
+  private String latestChronometricAge;
+  private String latestChronometricAgeReferenceSystem;
+  private Integer chronometricAgeUncertaintyInYears;
+  private String chronometricAgeUncertaintyMethod;
+  private String materialDated;
+  private String materialDatedID;
+  private String materialDatedRelationship;
+  private String chronometricAgeDeterminedBy;
+  private String chronometricAgeDeterminedByID;
+  private String chronometricAgeDeterminedDate;
+  private String chronometricAgeReferences;
+  private String chronometricAgeRemarks;
+}

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpChronometricAgeAgent.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpChronometricAgeAgent.java
@@ -1,0 +1,19 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpChronometricAgeAgent implements Serializable {
+    
+    @Serial
+    private static final long serialVersionUID = 1L;
+    private String agentID;
+    private String chronometricAgeID;
+    private String agentRole;
+    private String agentRoleIRI;
+    private String agentRoleVocabulary;
+    private Integer agentRoleOrder;
+    private String agentRoleDate;
+}

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpClasses.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpClasses.java
@@ -16,7 +16,14 @@ public enum DwcDpClasses {
   MEDIA("media.csv", "media", DwcDpMedia.class),
   OCCURRENCE("occurrence.csv", "occurrence", DwcDpOccurrence.class),
   RELATIONSHIP("relationship.csv", "relationship", DwcDpRelationship.class),
-  IDENTIFICATION_TAXON("identification-taxon.csv", "identification-taxon", DwcDpTaxonIdentification.class);
+  IDENTIFICATION_TAXON("identification-taxon.csv", "identification-taxon", DwcDpTaxonIdentification.class),
+  MATERIAL_ASSERTION("material-assertion.csv", "material-assertion", DwcDpMaterialAssertion.class),
+  EVENT_ASSERTION("event-assertion.csv", "event-assertion", DwcDpEventAssertion.class),
+  MATERIAL_REFERENCE("material-reference.csv", "material-reference", DwcDpMaterialReference.class),
+  REFERENCE("reference.csv", "reference", DwcDpReference.class),
+  GEOLOGICAL_CONTEXT("geological-context.csv", "geological-context", DwcDpGeologicalContext.class),
+  CHRONOMETRIC_AGE("chronometric-age.csv", "chronometric-age", DwcDpChronometricAge.class),
+  CHRONOMETRIC_AGE_AGENT("chronometric-age-agent-role.csv", "chronometric-age-agent-role", DwcDpChronometricAgeAgent.class);
   
   
   private final String fileName;

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpEventAssertion.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpEventAssertion.java
@@ -1,0 +1,33 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpEventAssertion implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private String assertionID;
+  private String eventID;
+  private String verbatimAssertionType;
+  private String assertionType;
+  private String assertionTypeIRI;
+  private String assertionTypeVocabulary;
+  private String assertionMadeDate;
+  private String assertionEffectiveDate;
+  private String assertionValue;
+  private String assertionValueIRI;
+  private String assertionValueVocabulary;
+  private Double assertionValueNumeric;
+  private String assertionUnit;
+  private String assertionUnitIRI;
+  private String assertionUnitVocabulary;
+  private String assertionBy;
+  private String assertionByID;
+  private String assertionProtocols;
+  private String assertionProtocolID;
+  private String assertionReferences;
+  private String assertionRemarks;
+}

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpGeologicalContext.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpGeologicalContext.java
@@ -1,0 +1,31 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpGeologicalContext implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private String geologicalContextID;
+  private String eventID;
+  private String earliestEonOrLowestEonothem;
+  private String latestEonOrHighestEonothem;
+  private String earliestEraOrLowestErathem;
+  private String latestEraOrHighestErathem;
+  private String earliestPeriodOrLowestSystem;
+  private String latestPeriodOrHighestSystem;
+  private String earliestEpochOrLowestSeries;
+  private String latestEpochOrHighestSeries;
+  private String earliestAgeOrLowestStage;
+  private String latestAgeOrHighestStage;
+  private String lowestBiostratigraphicZone;
+  private String highestBiostratigraphicZone;
+  private String lithostratigraphicTerms;
+  private String group;
+  private String formation;
+  private String member;
+  private String bed;
+}

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpMaterialAssertion.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpMaterialAssertion.java
@@ -1,0 +1,34 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpMaterialAssertion implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private String assertionID;
+  private String materialEntityID;
+  private String verbatimAssertionType;
+  private String assertionType;
+  private String assertionTypeIRI;
+  private String assertionTypeVocabulary;
+  private String assertionMadeDate;
+  private String assertionEffectiveDate;
+  private String assertionValue;
+  private String assertionValueIRI;
+  private String assertionValueVocabulary;
+  private Double assertionValueNumeric;
+  private String assertionUnit;
+  private String assertionUnitIRI;
+  private String assertionUnitVocabulary;
+  private String assertionBy;
+  private String assertionByID;
+  private String assertionProtocols;
+  private String assertionProtocolID;
+  private String assertionReferences;
+  private String assertionRemarks;
+
+}

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpMaterialReference.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpMaterialReference.java
@@ -1,0 +1,14 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpMaterialReference implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private String referenceID;
+  private String materialEntityID;
+}

--- a/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpReference.java
+++ b/src/main/java/eu/dissco/exportjob/domain/dwcdp/DwcDpReference.java
@@ -1,0 +1,26 @@
+package eu.dissco.exportjob.domain.dwcdp;
+
+import java.io.Serial;
+import java.io.Serializable;
+import lombok.Data;
+
+@Data
+public class DwcDpReference implements Serializable {
+
+  @Serial
+  private static final long serialVersionUID = 1L;
+  private String referenceID;
+  private String parentReferenceID;
+  private String referenceType;
+  private String bibliographicCitation;
+  private String title;
+  private String issued;
+  private String identifier;
+  private String creator;
+  private String creatorID;
+  private String publisher;
+  private String publisherID;
+  private String pagination;
+  private Boolean isPeerReviewed;
+  private String referenceRemarks;
+}

--- a/src/main/java/eu/dissco/exportjob/service/DwcaService.java
+++ b/src/main/java/eu/dissco/exportjob/service/DwcaService.java
@@ -2,6 +2,7 @@ package eu.dissco.exportjob.service;
 
 import static eu.dissco.exportjob.utils.ExportUtils.EXCLUDE_IDENTIFIERS;
 import static eu.dissco.exportjob.utils.ExportUtils.EXCLUDE_RELATIONSHIPS;
+import static eu.dissco.exportjob.utils.ExportUtils.convertValueToString;
 import static eu.dissco.exportjob.utils.ExportUtils.retrieveCombinedAgentId;
 import static eu.dissco.exportjob.utils.ExportUtils.retrieveCombinedAgentName;
 import static eu.dissco.exportjob.utils.ExportUtils.retrieveIdentifier;
@@ -18,6 +19,7 @@ import eu.dissco.exportjob.repository.ElasticSearchRepository;
 import eu.dissco.exportjob.repository.S3Repository;
 import eu.dissco.exportjob.repository.SourceSystemRepository;
 import eu.dissco.exportjob.schema.Agent;
+import eu.dissco.exportjob.schema.Assertion;
 import eu.dissco.exportjob.schema.Citation;
 import eu.dissco.exportjob.schema.DigitalMedia;
 import eu.dissco.exportjob.schema.DigitalSpecimen;
@@ -38,11 +40,13 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.tuple.Pair;
 import org.gbif.dwc.terms.AcTerm;
+import org.gbif.dwc.terms.ChronoTerm;
 import org.gbif.dwc.terms.DcTerm;
 import org.gbif.dwc.terms.DwcTerm;
 import org.gbif.dwc.terms.DwcaTerm;
 import org.gbif.dwc.terms.ExifTerm;
 import org.gbif.dwc.terms.GbifTerm;
+import org.gbif.dwc.terms.ObisTerm;
 import org.gbif.dwc.terms.Term;
 import org.gbif.dwc.terms.XmpRightsTerm;
 import org.gbif.dwc.terms.XmpTerm;
@@ -72,6 +76,10 @@ public class DwcaService extends AbstractExportJobService {
       .getFirst().getOdsHasLocation().getOdsHasGeologicalContext();
   public static final Function<DigitalSpecimen, Object> GEOREFERENCE_GET = ds -> ds.getOdsHasEvents()
       .getFirst().getOdsHasLocation().getOdsHasGeoreference();
+
+  private static final String OCCURRENCE_ID = "dwc:occurrenceID";
+  private static final String UNIT_GUID = "abcd:unitGUID";
+  private static final String UNIT_ID = "abcd:unitID";
 
 
   private final ObjectMapper objectMapper;
@@ -138,12 +146,16 @@ public class DwcaService extends AbstractExportJobService {
     var identifierList = new ArrayList<List<Pair<Term, String>>>();
     var relationshipList = new ArrayList<List<Pair<Term, String>>>();
     var digitalMediaList = new ArrayList<List<Pair<Term, String>>>();
+    var assertionList = new ArrayList<List<Pair<Term, String>>>();
+    var chronometricAgeList = new ArrayList<List<Pair<Term, String>>>();
     for (var digitalSpecimen : digitalSpecimenList) {
       addOccurrence(digitalSpecimen, occurrenceList);
       addIdentifications(digitalSpecimen, identificationList, referenceList);
       addIdentifiers(digitalSpecimen, identifierList);
       addRelationships(digitalSpecimen, relationshipList);
       addReference(digitalSpecimen.getOdsHasCitations(), digitalSpecimen.getId(), referenceList);
+      addAnnotation(digitalSpecimen, assertionList);
+      addChronometricAge(digitalSpecimen, chronometricAgeList);
       var media = specimenToDigitalMediaMapping.get(digitalSpecimen.getId());
       if (media != null && !media.isEmpty()) {
         addDigitalMedia(specimenToDigitalMediaMapping.get(digitalSpecimen.getId()),
@@ -156,7 +168,55 @@ public class DwcaService extends AbstractExportJobService {
     mappedList.put(GbifTerm.Reference, referenceList);
     mappedList.put(DwcTerm.ResourceRelationship, relationshipList);
     mappedList.put(AcTerm.Multimedia, digitalMediaList);
+    mappedList.put(ChronoTerm.ChronometricAge, chronometricAgeList);
     return mappedList;
+  }
+
+  private void addChronometricAge(DigitalSpecimen digitalSpecimen,
+      ArrayList<List<Pair<Term, String>>> chronometricAgeList) {
+    if (digitalSpecimen.getOdsHasChronometricAges() != null
+        && !digitalSpecimen.getOdsHasChronometricAges().isEmpty()) {
+      for (var chronometricAge : digitalSpecimen.getOdsHasChronometricAges()) {
+        var chronometricAgeRecord = new ArrayList<Pair<Term, String>>();
+        chronometricAgeRecord.add(Pair.of(DwcaTerm.ID, digitalSpecimen.getId()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeID,
+            chronometricAge.getChronoChronometricAgeID()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.verbatimChronometricAge,
+            chronometricAge.getChronoVerbatimChronometricAge()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeProtocol,
+            chronometricAge.getChronoChronometricAgeProtocol()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.uncalibratedChronometricAge,
+            chronometricAge.getChronoUncalibratedChronometricAge()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeConversionProtocol,
+            chronometricAge.getChronoChronometricAgeConversionProtocol()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.earliestChronometricAge,
+            convertValueToString(chronometricAge.getChronoEarliestChronometricAge())));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.earliestChronometricAgeReferenceSystem,
+            chronometricAge.getChronoEarliestChronometricAgeReferenceSystem()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.latestChronometricAge,
+            convertValueToString(chronometricAge.getChronoLatestChronometricAge())));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.latestChronometricAgeReferenceSystem,
+            chronometricAge.getChronoLatestChronometricAgeReferenceSystem()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeUncertaintyInYears,
+            getStringValue(chronometricAge.getChronoChronometricAgeUncertaintyInYears())));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeUncertaintyMethod,
+            chronometricAge.getChronoChronometricAgeUncertaintyMethod()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.materialDated,
+            chronometricAge.getChronoMaterialDated()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.materialDatedID,
+            chronometricAge.getChronoMaterialDatedID()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.materialDatedRelationship,
+            chronometricAge.getChronoMaterialDatedRelationship()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeDeterminedBy, retrieveCombinedAgentName(chronometricAge.getOdsHasAgents(), null)));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeDeterminedDate,
+            chronometricAge.getChronoChronometricAgeDeterminedDate()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeReferences,
+            chronometricAge.getChronoChronometricAgeReferences()));
+        chronometricAgeRecord.add(Pair.of(ChronoTerm.chronometricAgeRemarks,
+            chronometricAge.getChronoChronometricAgeRemarks()));
+        chronometricAgeList.add(chronometricAgeRecord);
+      }
+    }
   }
 
   private void mapEvent(DigitalSpecimen digitalSpecimen,
@@ -485,9 +545,9 @@ public class DwcaService extends AbstractExportJobService {
         digitalSpecimen.getDwcDataGeneralizations()));
     occurrenceList.add(Pair.of(DwcTerm.occurrenceID,
         retrieveIdentifier(digitalSpecimen,
-            List.of("dwc:occurrenceID", "abcd:unitGUID", "abcd:unitID"))));
+            List.of(OCCURRENCE_ID, UNIT_GUID, UNIT_ID))));
     occurrenceList.add(Pair.of(DwcTerm.catalogNumber,
-        retrieveIdentifier(digitalSpecimen, List.of("dwc:catalogNumber", "abcd:unitID"))));
+        retrieveIdentifier(digitalSpecimen, List.of("dwc:catalogNumber", UNIT_ID))));
     occurrenceList.add(Pair.of(DwcTerm.recordedBy,
         retrieveCombinedAgentName(digitalSpecimen.getOdsHasAgents(), "collector")));
     occurrenceList.add(Pair.of(DwcTerm.recordNumber,
@@ -690,6 +750,50 @@ public class DwcaService extends AbstractExportJobService {
     relationshipRecord.add(Pair.of(DwcTerm.relationshipRemarks,
         relationship.getDwcRelationshipRemarks()));
     return relationshipRecord;
+  }
+
+  // Collect any assertion on either specimen or associated first event (as only first event is included in the occurrence record)
+  private void addAnnotation(DigitalSpecimen digitalSpecimen,
+      ArrayList<List<Pair<Term, String>>> assertionList) {
+    if (digitalSpecimen.getOdsHasAssertions() != null && !digitalSpecimen.getOdsHasAssertions()
+        .isEmpty()) {
+      for (var assertion : digitalSpecimen.getOdsHasAssertions()) {
+        mapAssertion(digitalSpecimen, assertionList, assertion);
+      }
+    }
+    if (digitalSpecimen.getOdsHasEvents() != null && !digitalSpecimen.getOdsHasEvents().isEmpty()) {
+      var event = digitalSpecimen.getOdsHasEvents().getFirst();
+      if (event.getOdsHasAssertions() != null && !event.getOdsHasAssertions().isEmpty()) {
+        for (var assertion : event.getOdsHasAssertions()) {
+          mapAssertion(digitalSpecimen, assertionList, assertion);
+        }
+      }
+    }
+  }
+
+  private void mapAssertion(DigitalSpecimen digitalSpecimen,
+      ArrayList<List<Pair<Term, String>>> assertionList, Assertion assertion) {
+    var assertionRecord = new ArrayList<Pair<Term, String>>();
+    assertionRecord.add(Pair.of(DwcaTerm.ID, digitalSpecimen.getId()));
+    assertionRecord.add(Pair.of(DwcTerm.measurementID, assertion.getDwcMeasurementID()));
+    assertionRecord.add(Pair.of(DwcTerm.occurrenceID,
+        retrieveIdentifier(digitalSpecimen, List.of(OCCURRENCE_ID, UNIT_GUID, UNIT_ID))));
+    assertionRecord.add(Pair.of(DwcTerm.measurementType, assertion.getDwcMeasurementType()));
+    assertionRecord.add(Pair.of(ObisTerm.measurementTypeID, assertion.getDwciriMeasurementType()));
+    assertionRecord.add(Pair.of(DwcTerm.measurementValue, assertion.getDwcMeasurementValue()));
+    assertionRecord.add(
+        Pair.of(ObisTerm.measurementValueID, assertion.getDwciriMeasurementValue()));
+    assertionRecord.add(
+        Pair.of(DwcTerm.measurementAccuracy, assertion.getDwcMeasurementAccuracy()));
+    assertionRecord.add(Pair.of(DwcTerm.measurementUnit, assertion.getDwcMeasurementUnit()));
+    assertionRecord.add(
+        Pair.of(ObisTerm.measurementValueID, assertion.getDwciriMeasurementValue()));
+    assertionRecord.add(
+        Pair.of(DwcTerm.measurementDeterminedDate, assertion.getDwcMeasurementDeterminedDate()));
+    assertionRecord.add(Pair.of(DwcTerm.measurementDeterminedBy,
+        retrieveCombinedAgentName(assertion.getOdsHasAgents(), "measurer")));
+    assertionRecord.add(Pair.of(DwcTerm.measurementRemarks, assertion.getDwcMeasurementRemarks()));
+    assertionList.add(assertionRecord);
   }
 
   private Map<String, List<DigitalMedia>> createSpecimenToMediaMapping(

--- a/src/main/java/eu/dissco/exportjob/utils/ExportUtils.java
+++ b/src/main/java/eu/dissco/exportjob/utils/ExportUtils.java
@@ -2,6 +2,7 @@ package eu.dissco.exportjob.utils;
 
 import eu.dissco.exportjob.exceptions.FailedProcessingException;
 import eu.dissco.exportjob.schema.Agent;
+import eu.dissco.exportjob.schema.Citation;
 import eu.dissco.exportjob.schema.DigitalSpecimen;
 import eu.dissco.exportjob.schema.Identifier;
 import eu.dissco.exportjob.schema.OdsHasRole;
@@ -12,6 +13,7 @@ import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 public class ExportUtils {
 
@@ -55,7 +57,7 @@ public class ExportUtils {
       return null;
     }
     List<String> agentIds = new ArrayList<>();
-    for (Agent agent : odsHasAgents) {
+    for (var agent : odsHasAgents) {
       if (roleName == null || agent.getOdsHasRoles().stream()
           .anyMatch(role -> role.getSchemaRoleName().equals(roleName))) {
         String agentId = agent.getSchemaIdentifier();
@@ -72,7 +74,7 @@ public class ExportUtils {
       return null;
     }
     List<String> agentNames = new ArrayList<>();
-    for (Agent agent : odsHasAgents) {
+    for (var agent : odsHasAgents) {
       if (roleName == null || agent.getOdsHasRoles().stream()
           .anyMatch(role -> role.getSchemaRoleName().equals(roleName))) {
         String agentName = agent.getSchemaName();
@@ -84,7 +86,19 @@ public class ExportUtils {
     return String.join(" | ", agentNames);
   }
 
-  public static String retrieveTerm(DigitalSpecimen digitalSpecimen, Predicate<DigitalSpecimen> condition,
+
+  public static String retrieveCombinedCitation(List<Citation> odsHasCitation) {
+    if (odsHasCitation == null || odsHasCitation.isEmpty()) {
+      return null;
+    }
+    return odsHasCitation.stream()
+        .map(Citation::getDctermsBibliographicCitation)
+        .filter(Objects::nonNull)
+        .collect(Collectors.joining(" | "));
+  }
+
+  public static String retrieveTerm(DigitalSpecimen digitalSpecimen,
+      Predicate<DigitalSpecimen> condition,
       Function<DigitalSpecimen, Object> extractor, String methodName)
       throws FailedProcessingException {
     if (condition.test(digitalSpecimen)) {
@@ -106,6 +120,13 @@ public class ExportUtils {
       throw new FailedProcessingException("Failed to retrieve value from class", e);
     }
     return null;
+  }
+
+  public static String convertValueToString(Object value) {
+    if (value == null) {
+      return null;
+    }
+    return String.valueOf(value);
   }
 
 }

--- a/src/test/java/eu/dissco/exportjob/service/DwcDpServiceTest.java
+++ b/src/test/java/eu/dissco/exportjob/service/DwcDpServiceTest.java
@@ -606,7 +606,7 @@ class DwcDpServiceTest {
     service.setup();
 
     // Then
-    then(databaseRepository).should(times(13)).createTable(anyString());
+    then(databaseRepository).should(times(20)).createTable(anyString());
   }
 
   @Test
@@ -618,6 +618,6 @@ class DwcDpServiceTest {
     service.cleanup();
 
     // Then
-    then(databaseRepository).should(times(13)).dropTable(anyString());
+    then(databaseRepository).should(times(20)).dropTable(anyString());
   }
 }

--- a/src/test/java/eu/dissco/exportjob/utils/TestUtils.java
+++ b/src/test/java/eu/dissco/exportjob/utils/TestUtils.java
@@ -521,6 +521,14 @@ public class TestUtils {
                   ]
                 }
               ],
+              "ods:hasAssertions": [
+                {
+                  "dwc:measurementType": "lifestage",
+                  "dwciri:measurementType": "vocab.nerc.ac.uk/collection/P01/current/LSTAGE01",
+                  "dwc:measurementValue": "juvenile",
+                  "dwciri:measurementValue": "http://vocab.nerc.ac.uk/collection/S11/current/S1127"
+                }
+              ],
               "ods:hasIdentifiers": [
                 {
                   "@id": "79569268-d66d-4899-b3f7-aafeb13069d0",
@@ -562,6 +570,35 @@ public class TestUtils {
                   "dcterms:bibliographicCitation": "Seregin A. P. (Ed.). 2025. Specimen MW0589635 from the collection Moscow University Herbarium // Depository of Live Systems (branch Plants): Electronic resource. – Moscow State University, Moscow. – Available at: https://plant.depo.mitotech.ru/open/public/item/MW0589635 (indicate access date)."
                 }
               ],
+              "ods:hasChronometricAges": [
+                  {
+                    "chrono:verbatimChronometricAge": "27 BC to 14 AD",
+                    "chrono:chronometricAgeConversionProtocol": "INTCAL13",
+                    "ods:hasAgents": [
+                      {
+                        "@type": "schema:Person",
+                        "@id": "https://orcid.org/0000-0002-5669-2769",
+                        "schema:identifier": "https://orcid.org/0000-0002-5669-2769",
+                        "schema:name": "Sam Leeflang",
+                        "ods:hasRoles": [
+                          {
+                            "@type": "schema:Role",
+                            "schema:roleName": "determiner"
+                          }
+                        ],
+                        "ods:hasIdentifiers": [
+                          {
+                            "@id": "https://orcid.org/0000-0002-5669-2769",
+                            "@type": "ods:Identifier",
+                            "dcterms:title": "orcid",
+                            "dcterms:identifier": "https://orcid.org/0000-0002-5669-2769",
+                            "ods:gupriLevel": "GloballyUniqueStable"
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                ],
               "ods:hasEvents": [
                 {
                   "@type": "ods:Event",
@@ -607,6 +644,14 @@ public class TestUtils {
                           "schema:roleName": "collector"
                         }
                       ]
+                    }
+                  ],
+                  "ods:hasAssertions": [
+                    {
+                      "dwc:measurementType": "lifestage",
+                      "dwciri:measurementType": "vocab.nerc.ac.uk/collection/P01/current/LSTAGE01",
+                      "dwc:measurementValue": "juvenile",
+                      "dwciri:measurementValue": "http://vocab.nerc.ac.uk/collection/S11/current/S1127"
                     }
                   ],
                   "ods:hasLocation": {


### PR DESCRIPTION
Adding support for additional data mappings for DWCA and DwC-DP export products.
This data is not regularly filled, but if it is, we want to include it.

- Adding support for ExtendedMeasurementOrFact DWCA extensions
- Adding support for ChronometricAge DWCA extension
- Adding support for MaterialAssertion in DwC-DP
- Adding support for EventAssertion in DwC-DP
- Adding support for MaterialReference in DwC-DP
- Adding support for Reference in DwC-DP
- Adding support for GeologicalContext in DwC-DP
- Adding support for ChronometricAge in DwC-DP
- Adding support for ChronometricAgeAgentRole in DwC-DP

DWCA mapping based on extensions: https://rs.gbif.org/extensions.html
DwC-DP mapping based on dwc-dp docs: https://github.com/gbif/dwc-dp/tree/master

Jira: https://naturalis.atlassian.net/browse/DD-1935?atlOrigin=eyJpIjoiZjhlMzIxYzVhZDYzNDcwNjlhNTExMmY0ZmQ5MjhmNTkiLCJwIjoiaiJ9